### PR TITLE
added test showing mixed data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ script:
   - npm run coverage
 
     # run coverage and file size checks
-  - npm run coverage:upload || true #ignore failures
+  # - npm run coverage:upload || true #ignore failures
 
     # make sure files don't get too large
   - npm run filesize

--- a/src/__tests__/advanced.ts
+++ b/src/__tests__/advanced.ts
@@ -1,0 +1,105 @@
+import gql from 'graphql-tag';
+import { ApolloLink, execute, Observable } from 'apollo-link';
+import { ApolloClient } from 'apollo-client';
+import { InMemoryCache } from 'apollo-cache-inmemory';
+
+import { withClientState } from '../';
+
+describe('server and client state', () => {
+  const query = gql`
+    query list {
+      list(name: "my list") {
+        items {
+          id
+          name
+          isDone
+          isSelected @client
+        }
+      }
+    }
+  `;
+  it('works to merge remote and local state', done => {
+    const data = {
+      list: {
+        __typename: 'List',
+        items: [
+          { __typename: 'ListItem', id: 1, name: 'first', isDone: true },
+          { __typename: 'ListItem', id: 2, name: 'second', isDone: false },
+        ],
+      },
+    };
+    // mocked endpoint acting as server data
+    const http = new ApolloLink(() => Observable.of({ data }));
+
+    const local = withClientState({
+      Mutation: {
+        toggleItem: (_, { id }, { cache }) => {
+          id = `ListItem:${id}`;
+          const fragment = gql`
+            fragment item on ListItem {
+              __typename
+              isSelected
+            }
+          `;
+          const previous = cache.readFragment({ fragment, id });
+          const data = {
+            ...previous,
+            isSelected: !previous.isSelected,
+          };
+          cache.writeFragment({
+            id,
+            fragment,
+            data,
+          });
+
+          return data;
+        },
+      },
+      ListItem: {
+        isSelected: (source, args, context) => {
+          expect(source.name).toBeDefined();
+          // list items default to an unselected state
+          return false;
+        },
+      },
+    });
+
+    const client = new ApolloClient({
+      link: local.concat(http),
+      cache: new InMemoryCache(),
+    });
+
+    const observer = client.watchQuery({ query });
+
+    let count = 0;
+    const sub = observer.subscribe({
+      next: response => {
+        if (count === 0) {
+          const initial = { ...data };
+          initial.list.items = initial.list.items.map(x => ({
+            ...x,
+            isSelected: false,
+          }));
+          expect(response.data).toMatchObject(initial);
+        }
+        if (count === 1) {
+          expect(response.data.list.items[0].isSelected).toBe(true);
+          expect(response.data.list.items[1].isSelected).toBe(false);
+          done();
+        }
+        count++;
+      },
+      error: done.fail,
+    });
+    const variables = { id: 1 };
+    const mutation = gql`
+      mutation SelectItem($id: Int!) {
+        toggleItem(id: $id) @client
+      }
+    `;
+    // after initial result, toggle the state of one of the items
+    setTimeout(() => {
+      client.mutate({ mutation, variables });
+    }, 10);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ export const withClientState = resolvers => {
             // Look for the field in the custom resolver map
             const resolve =
               resolvers[(rootValue as any).__typename || type][fieldName];
-            if (resolve) return resolve(fieldValue, args, context, info);
+            if (resolve) return resolve(rootValue, args, context, info);
           };
 
           const mergedData = graphql(


### PR DESCRIPTION
@glasser @stubailo @peggyrayzis 

Thinking in documents (queries / fragments) has been super nice in these tests. I can see the desire for a lower level API, but so far I'm super happy with how this works. I think with a few helpers around `{read|write}{Query|Fragment}`, this could be a pretty great way to think through the cache