### PR TITLE
fix for aliases in server query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### vNEXT
 
+### 0.0.4
+- fix to use aliases in server-side query responses
+
 ### 0.0.3
 - fix mutation of operation breaking context access
 

--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -175,6 +175,31 @@ it('runs resolvers for missing client queries with variables', done => {
   }, done.fail);
 });
 
+it('runs resolvers for missing client queries with aliased field', done => {
+  const query = gql`
+    query Aliased {
+      foo @client {
+        bar
+      }
+      baz: bar {
+        foo
+      }
+    }
+  `;
+  const sample = new ApolloLink(() =>
+    Observable.of({ data: { baz: { foo: true } } }),
+  );
+  const client = withClientState({
+    Query: {
+      foo: () => ({ bar: true }),
+    },
+  });
+  execute(client.concat(sample), { query }).subscribe(({ data }) => {
+    expect(data).toEqual({ foo: { bar: true }, baz: { foo: true } });
+    done();
+  }, done.fail);
+});
+
 it('passes context to client resolvers', done => {
   const query = gql`
     query WithContext {

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,12 +27,14 @@ export const withClientState = resolvers => {
       const sub = obs.subscribe({
         next: ({ data, errors }) => {
           const resolver = (fieldName, rootValue = {}, args, context, info) => {
-            const fieldValue = rootValue[fieldName];
+            const fieldValue = rootValue[info.resultKey || fieldName];
             if (fieldValue !== undefined) return fieldValue;
 
             // Look for the field in the custom resolver map
             const resolve =
-              resolvers[(rootValue as any).__typename || type][fieldName];
+              resolvers[(rootValue as any).__typename || type][
+                info.resultKey || fieldName
+              ];
             if (resolve) return resolve(rootValue, args, context, info);
           };
 


### PR DESCRIPTION
## Issue
The local resolver wasn't being made to recognize and handle aliases in server-side portions of the query.

## Solution
in the following query:

```
{
  foo @client { bar }
  baz: bar { foo }
}
```

The observer was looking for `bar` in the server portion instead of `baz`. I added a check for an aliased field (`info.resultKey`) in the observer.