### PR TITLE
added check on forward (next link)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ export const withClientState = resolvers => {
 
     return new Observable(observer => {
       if (server) operation.query = server;
-      const obs = server ? forward(operation) : Observable.of({ data: {} });
+      const obs = (server && forward) ? forward(operation) : Observable.of({ data: {} });
 
       const sub = obs.subscribe({
         next: ({ data, errors }) => {


### PR DESCRIPTION
this little change will give us ability to create one link only (apollo-link-state) and move our server-side resolvers to client-side. for situations when we cant have server-side graphql.