### PR TITLE
Increment versions

### DIFF
--- a/examples/async/package.json
+++ b/examples/async/package.json
@@ -1,6 +1,6 @@
 {
   "name": "async",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "devDependencies": {
     "react-scripts": "^1.0.2"

--- a/examples/todo/package.json
+++ b/examples/todo/package.json
@@ -2,7 +2,7 @@
   "name": "todos",
   "private": true,
   "description": null,
-  "version": "0.0.0",
+  "version": "0.0.1",
   "dependencies": {
     "apollo-cache-inmemory": "1.0.0",
     "apollo-client": "^2.0.1",

--- a/packages/apollo-link-state/package.json
+++ b/packages/apollo-link-state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-link-state",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "An easy way to manage local state with Apollo Link",
   "author": "James Baxley <james@meteor.com>",
   "license": "MIT",


### PR DESCRIPTION
 - apollo-link-state@0.2.0
 - async@0.0.2
 - todos@0.0.1

Lerna published to my `origin` remote branch instead of `upstream` 😞 