### PR TITLE
Updated withClientState to take a config object

### DIFF
--- a/packages/apollo-link-state/CHANGELOG.md
+++ b/packages/apollo-link-state/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change log
 
 ### vNEXT
+- BREAKING: Changed `withClientState` API to take a config object with `resolvers`, `defaults`, and `cache` properties: [#132](https://github.com/apollographql/apollo-link-state/pull/132)
+- Fix overriding fragment parent's __typename: [#131](https://github.com/apollographql/apollo-link-state/pull/131)
+
+### 0.2.0
+- Added `cache.writeData` to easily write data to the cache: [#123](https://github.com/apollographql/apollo-link-state/pull/123)
 
 ### 0.1.0
 - official async support

--- a/packages/apollo-link-state/src/__tests__/__snapshots__/initialization.ts.snap
+++ b/packages/apollo-link-state/src/__tests__/__snapshots__/initialization.ts.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`initialization writes defaults to the cache upon initialization 1`] = `
+Object {
+  "$ROOT_QUERY.foo": Object {
+    "__typename": "Bar",
+    "bar": false,
+  },
+  "ROOT_QUERY": Object {
+    "foo": Object {
+      "generated": true,
+      "id": "$ROOT_QUERY.foo",
+      "type": "id",
+    },
+  },
+}
+`;

--- a/packages/apollo-link-state/src/__tests__/advanced.ts
+++ b/packages/apollo-link-state/src/__tests__/advanced.ts
@@ -32,34 +32,36 @@ describe('server and client state', () => {
     const http = new ApolloLink(() => Observable.of({ data }));
 
     const local = withClientState({
-      Mutation: {
-        toggleItem: async (_, { id }, { cache }) => {
-          id = `ListItem:${id}`;
-          const fragment = gql`
-            fragment item on ListItem {
-              __typename
-              isSelected
-            }
-          `;
-          const previous = cache.readFragment({ fragment, id });
-          const data = {
-            ...previous,
-            isSelected: !previous.isSelected,
-          };
-          await cache.writeFragment({
-            id,
-            fragment,
-            data,
-          });
+      resolvers: {
+        Mutation: {
+          toggleItem: async (_, { id }, { cache }) => {
+            id = `ListItem:${id}`;
+            const fragment = gql`
+              fragment item on ListItem {
+                __typename
+                isSelected
+              }
+            `;
+            const previous = cache.readFragment({ fragment, id });
+            const data = {
+              ...previous,
+              isSelected: !previous.isSelected,
+            };
+            await cache.writeFragment({
+              id,
+              fragment,
+              data,
+            });
 
-          return data;
+            return data;
+          },
         },
-      },
-      ListItem: {
-        isSelected: (source, args, context) => {
-          expect(source.name).toBeDefined();
-          // list items default to an unselected state
-          return false;
+        ListItem: {
+          isSelected: (source, args, context) => {
+            expect(source.name).toBeDefined();
+            // list items default to an unselected state
+            return false;
+          },
         },
       },
     });

--- a/packages/apollo-link-state/src/__tests__/client.ts
+++ b/packages/apollo-link-state/src/__tests__/client.ts
@@ -17,7 +17,7 @@ describe('non cache usage', () => {
     `;
 
     const link = new ApolloLink(() => Observable.of({ data: { field: 1 } }));
-    const local = withClientState({ resolvers: {} });
+    const local = withClientState();
 
     const client = new ApolloClient({
       cache: new InMemoryCache(),
@@ -131,6 +131,25 @@ describe('non cache usage', () => {
 });
 
 describe('cache usage', () => {
+  it('still lets you query the cache without passing in a resolver map', () => {
+    const query = gql`
+      {
+        field @client
+      }
+    `;
+
+    const cache = new InMemoryCache();
+    const client = new ApolloClient({
+      cache,
+      link: withClientState(),
+    });
+
+    cache.writeQuery({ query, data: { field: 'yo' } });
+
+    client
+      .query({ query })
+      .then(({ data }) => expect({ ...data }).toEqual({ field: 'yo' }));
+  });
   it('lets you write to the cache with a mutation', () => {
     const query = gql`
       {

--- a/packages/apollo-link-state/src/__tests__/client.ts
+++ b/packages/apollo-link-state/src/__tests__/client.ts
@@ -17,7 +17,7 @@ describe('non cache usage', () => {
     `;
 
     const link = new ApolloLink(() => Observable.of({ data: { field: 1 } }));
-    const local = withClientState({});
+    const local = withClientState({ resolvers: {} });
 
     const client = new ApolloClient({
       cache: new InMemoryCache(),
@@ -36,8 +36,10 @@ describe('non cache usage', () => {
     `;
 
     const local = withClientState({
-      Query: {
-        field: () => 1,
+      resolvers: {
+        Query: {
+          field: () => 1,
+        },
       },
     });
 
@@ -59,10 +61,12 @@ describe('non cache usage', () => {
 
     let count = 0;
     const local = withClientState({
-      Query: {
-        field: () => {
-          count++;
-          return 1;
+      resolvers: {
+        Query: {
+          field: () => {
+            count++;
+            return 1;
+          },
         },
       },
     });
@@ -94,10 +98,12 @@ describe('non cache usage', () => {
 
     let count = 0;
     const local = withClientState({
-      Query: {
-        field: () => {
-          count++;
-          return 1;
+      resolvers: {
+        Query: {
+          field: () => {
+            count++;
+            return 1;
+          },
         },
       },
     });
@@ -139,10 +145,12 @@ describe('cache usage', () => {
     `;
 
     const local = withClientState({
-      Mutation: {
-        start: (_, $, { cache }: { cache: InMemoryCache }) => {
-          cache.writeQuery({ query, data: { field: 1 } });
-          return { start: true };
+      resolvers: {
+        Mutation: {
+          start: (_, $, { cache }: { cache: InMemoryCache }) => {
+            cache.writeQuery({ query, data: { field: 1 } });
+            return { start: true };
+          },
         },
       },
     });
@@ -173,13 +181,15 @@ describe('cache usage', () => {
     `;
 
     const local = withClientState({
-      Query: {
-        field: () => 0,
-      },
-      Mutation: {
-        start: (_, $, { cache }: { cache: InMemoryCache }) => {
-          cache.writeQuery({ query, data: { field: 1 } });
-          return { start: true };
+      resolvers: {
+        Query: {
+          field: () => 0,
+        },
+        Mutation: {
+          start: (_, $, { cache }: { cache: InMemoryCache }) => {
+            cache.writeQuery({ query, data: { field: 1 } });
+            return { start: true };
+          },
         },
       },
     });
@@ -221,13 +231,15 @@ describe('cache usage', () => {
     `;
 
     const local = withClientState({
-      Mutation: {
-        start: (_, variables, { cache }) => {
-          cache.writeQuery({ query, data: { field: variables.field } });
-          return {
-            __typename: 'Field',
-            field: variables.field,
-          };
+      resolvers: {
+        Mutation: {
+          start: (_, variables, { cache }) => {
+            cache.writeQuery({ query, data: { field: variables.field } });
+            return {
+              __typename: 'Field',
+              field: variables.field,
+            };
+          },
         },
       },
     });
@@ -279,19 +291,21 @@ describe('sample usage', () => {
     };
 
     const local = withClientState({
-      Query: {
-        // initial count
-        count: () => 0,
-      },
-      Mutation: {
-        increment: update(query, ({ count, ...rest }, { amount }) => ({
-          ...rest,
-          count: count + amount,
-        })),
-        decrement: update(query, ({ count, ...rest }, { amount }) => ({
-          ...rest,
-          count: count - amount,
-        })),
+      resolvers: {
+        Query: {
+          // initial count
+          count: () => 0,
+        },
+        Mutation: {
+          increment: update(query, ({ count, ...rest }, { amount }) => ({
+            ...rest,
+            count: count + amount,
+          })),
+          decrement: update(query, ({ count, ...rest }, { amount }) => ({
+            ...rest,
+            count: count - amount,
+          })),
+        },
       },
     });
 
@@ -348,13 +362,15 @@ describe('sample usage', () => {
     };
 
     const local = withClientState({
-      Query: {
-        todos: () => [],
-      },
-      Mutation: {
-        addTodo: update(query, ({ todos }, { message, title }) => ({
-          todos: todos.concat([{ message, title, __typename: 'Todo' }]),
-        })),
+      resolvers: {
+        Query: {
+          todos: () => [],
+        },
+        Mutation: {
+          addTodo: update(query, ({ todos }, { message, title }) => ({
+            todos: todos.concat([{ message, title, __typename: 'Todo' }]),
+          })),
+        },
       },
     });
 

--- a/packages/apollo-link-state/src/__tests__/index.ts
+++ b/packages/apollo-link-state/src/__tests__/index.ts
@@ -64,6 +64,7 @@ it('strips out the client directive and does not call other links if no more fie
     done();
   }, done.fail);
 });
+
 it('passes a query on to the next link', done => {
   const nextLink = new ApolloLink(operation => {
     expect(operation.getContext()).toEqual({});

--- a/packages/apollo-link-state/src/__tests__/index.ts
+++ b/packages/apollo-link-state/src/__tests__/index.ts
@@ -46,7 +46,7 @@ const doubleData = {
   bar: { foo: false },
 };
 
-const defaultResolvers = {
+const resolvers = {
   Query: {
     foo: () => ({ bar: true }),
   },
@@ -57,7 +57,7 @@ it('strips out the client directive and does not call other links if no more fie
     done.fail(new Error('should not have called'));
   });
 
-  const client = withClientState(defaultResolvers);
+  const client = withClientState({ resolvers });
 
   execute(client.concat(nextLink), { query }).subscribe(result => {
     expect(result.data).toEqual({ foo: { bar: true } });
@@ -79,7 +79,7 @@ it('passes a query on to the next link', done => {
     return Observable.of({ data: { bar: { foo: true } } });
   });
 
-  const client = withClientState(defaultResolvers);
+  const client = withClientState({ resolvers });
 
   execute(client.concat(nextLink), { query: mixedQuery }).subscribe(
     () => done(),
@@ -89,8 +89,10 @@ it('passes a query on to the next link', done => {
 
 it('runs resolvers for client queries', done => {
   const client = withClientState({
-    Query: {
-      foo: () => ({ bar: true }),
+    resolvers: {
+      Query: {
+        foo: () => ({ bar: true }),
+      },
     },
   });
   execute(client, { query }).subscribe(({ data }) => {
@@ -113,11 +115,7 @@ it('runs resolvers for missing client queries with server data', done => {
   const sample = new ApolloLink(() =>
     Observable.of({ data: { bar: { baz: true } } }),
   );
-  const client = withClientState({
-    Query: {
-      foo: () => ({ bar: true }),
-    },
-  });
+  const client = withClientState({ resolvers });
   execute(client.concat(sample), { query }).subscribe(({ data }) => {
     expect(data).toEqual({ foo: { bar: true }, bar: { baz: true } });
     done();
@@ -142,11 +140,7 @@ it('runs resolvers for missing client queries with server data including fragmen
   const sample = new ApolloLink(() =>
     Observable.of({ data: { bar: { baz: true } } }),
   );
-  const client = withClientState({
-    Query: {
-      foo: () => ({ bar: true }),
-    },
-  });
+  const client = withClientState({ resolvers });
   execute(client.concat(sample), { query }).subscribe(({ data }) => {
     expect(data).toEqual({ foo: { bar: true }, bar: { baz: true } });
     done();
@@ -162,11 +156,13 @@ it('runs resolvers for missing client queries with variables', done => {
     }
   `;
   const client = withClientState({
-    Query: {
-      foo: () => ({ __typename: 'Foo' }),
-    },
-    Foo: {
-      bar: (data, { id }) => id,
+    resolvers: {
+      Query: {
+        foo: () => ({ __typename: 'Foo' }),
+      },
+      Foo: {
+        bar: (data, { id }) => id,
+      },
     },
   });
   execute(client, { query, variables: { id: 1 } }).subscribe(({ data }) => {
@@ -190,9 +186,7 @@ it('runs resolvers for missing client queries with aliased field', done => {
     Observable.of({ data: { baz: { foo: true } } }),
   );
   const client = withClientState({
-    Query: {
-      foo: () => ({ bar: true }),
-    },
+    resolvers,
   });
   execute(client.concat(sample), { query }).subscribe(({ data }) => {
     expect(data).toEqual({ foo: { bar: true }, baz: { foo: true } });
@@ -209,11 +203,13 @@ it('passes context to client resolvers', done => {
     }
   `;
   const client = withClientState({
-    Query: {
-      foo: () => ({ __typename: 'Foo' }),
-    },
-    Foo: {
-      bar: (data, _, { id }) => id,
+    resolvers: {
+      Query: {
+        foo: () => ({ __typename: 'Foo' }),
+      },
+      Foo: {
+        bar: (data, _, { id }) => id,
+      },
     },
   });
   execute(client, { query, context: { id: 1 } }).subscribe(({ data }) => {

--- a/packages/apollo-link-state/src/__tests__/initialization.ts
+++ b/packages/apollo-link-state/src/__tests__/initialization.ts
@@ -1,0 +1,53 @@
+import gql from 'graphql-tag';
+import { ApolloClient } from 'apollo-client';
+import { InMemoryCache } from 'apollo-cache-inmemory';
+
+import { withClientState } from '../';
+
+describe('initialization', () => {
+  const resolvers = { Query: { foo: () => ({ bar: true }) } };
+  const defaults = { foo: { bar: false, __typename: 'Bar' } };
+
+  it('attaches writeData to the cache if you pass in defaults', () => {
+    const cache = {
+      writeQuery: jest.fn(),
+    };
+
+    withClientState({ cache, resolvers, defaults });
+    expect('cache.writeData').toBeDefined();
+  });
+
+  it('writes defaults to the cache upon initialization', () => {
+    const cache = new InMemoryCache();
+
+    withClientState({ cache, resolvers, defaults });
+    expect(cache.extract()).toMatchSnapshot();
+  });
+
+  it(`doesn't call the resolver if the data is already in the cache`, () => {
+    const fooResolver = jest.fn();
+    const resolvers = { Query: { foo: fooResolver } };
+
+    const cache = new InMemoryCache();
+    const client = new ApolloClient({
+      cache,
+      link: withClientState({ cache, resolvers, defaults }),
+    });
+
+    const query = gql`
+      {
+        foo @client {
+          bar
+        }
+      }
+    `;
+
+    client
+      .query({ query })
+      .then(({ data }) => {
+        expect(fooResolver).not.toHaveBeenCalled();
+        expect(data.foo.bar).toEqual(false);
+      })
+      .catch(e => console.error(e));
+  });
+});

--- a/packages/apollo-link-state/src/__tests__/noQuery.ts
+++ b/packages/apollo-link-state/src/__tests__/noQuery.ts
@@ -96,10 +96,12 @@ describe('writing data with no query', () => {
       `;
 
       const local = withClientState({
-        Mutation: {
-          start: (_, $, { cache }: { cache: ApolloCacheClient }) => {
-            cache.writeData({ data: { field: 1 } });
-            return { start: true };
+        resolvers: {
+          Mutation: {
+            start: (_, $, { cache }: { cache: ApolloCacheClient }) => {
+              cache.writeData({ data: { field: 1 } });
+              return { start: true };
+            },
           },
         },
       });
@@ -133,14 +135,18 @@ describe('writing data with no query', () => {
       `;
 
       const local = withClientState({
-        Mutation: {
-          start: (_, $, { cache }: { cache: ApolloCacheClient }) => {
-            cache.writeQuery({
-              query,
-              data: { obj: { field: 1, id: 'uniqueId', __typename: 'Object' } },
-            });
-            cache.writeData({ id: 'Object:uniqueId', data: { field: 2 } });
-            return { start: true };
+        resolvers: {
+          Mutation: {
+            start: (_, $, { cache }: { cache: ApolloCacheClient }) => {
+              cache.writeQuery({
+                query,
+                data: {
+                  obj: { field: 1, id: 'uniqueId', __typename: 'Object' },
+                },
+              });
+              cache.writeData({ id: 'Object:uniqueId', data: { field: 2 } });
+              return { start: true };
+            },
           },
         },
       });

--- a/packages/apollo-link-state/src/index.ts
+++ b/packages/apollo-link-state/src/index.ts
@@ -25,13 +25,9 @@ export type WriteData = {
 
 export type ApolloCacheClient = ApolloCache<any> & WriteData;
 
-export const withClientState = ({ resolvers, defaults, cache }) => {
-  if (!resolvers) {
-    throw new Error(
-      `Resolvers are required to initialize the state link. Please see [DOCS link] for details`,
-    );
-  }
-
+export const withClientState = (
+  { resolvers, defaults, cache } = { resolvers: {} },
+) => {
   if (cache && defaults) {
     if (!cache.writeData) {
       addWriteDataToCache(cache);

--- a/packages/apollo-link-state/src/index.ts
+++ b/packages/apollo-link-state/src/index.ts
@@ -26,11 +26,11 @@ export type WriteData = {
 export type ApolloCacheClient = ApolloCache<any> & WriteData;
 
 export const withClientState = ({ resolvers, defaults, cache }) => {
-  // if (!cache | !resolvers | !defaults) {
-  //   throw new Error(
-  //     `One of the required configuration properties is missing. Please see [DOCS link] for details`,
-  //   );
-  // }
+  if (!resolvers) {
+    throw new Error(
+      `Resolvers are required to initialize the state link. Please see [DOCS link] for details`,
+    );
+  }
 
   if (cache && defaults) {
     if (!cache.writeData) {

--- a/packages/apollo-link-state/src/index.ts
+++ b/packages/apollo-link-state/src/index.ts
@@ -9,9 +9,9 @@ import { removeClientSetsFromDocument, addWriteDataToCache } from './utils';
 const capitalizeFirstLetter = str => str.charAt(0).toUpperCase() + str.slice(1);
 
 export type ClientStateConfig = {
-  cache: ApolloCacheClient;
+  cache?: ApolloCacheClient;
   resolvers: any;
-  defaults: any;
+  defaults?: any;
 };
 
 export type WriteDataArgs = {
@@ -26,7 +26,7 @@ export type WriteData = {
 export type ApolloCacheClient = ApolloCache<any> & WriteData;
 
 export const withClientState = (
-  { resolvers, defaults, cache } = { resolvers: {} },
+  { resolvers, defaults, cache }: ClientStateConfig = { resolvers: {} },
 ) => {
   if (cache && defaults) {
     if (!cache.writeData) {

--- a/packages/apollo-link-state/src/index.ts
+++ b/packages/apollo-link-state/src/index.ts
@@ -8,6 +8,12 @@ import { removeClientSetsFromDocument, addWriteDataToCache } from './utils';
 
 const capitalizeFirstLetter = str => str.charAt(0).toUpperCase() + str.slice(1);
 
+export type ClientStateConfig = {
+  cache: ApolloCache<any>;
+  resolvers: any;
+  defaults: any;
+};
+
 export type WriteDataArgs = {
   id?: string;
   data: any;
@@ -19,7 +25,7 @@ export type WriteData = {
 
 export type ApolloCacheClient = ApolloCache<any> & WriteData;
 
-export const withClientState = resolvers => {
+export const withClientState = ({ resolvers, defaults, cache }) => {
   return new ApolloLink((operation: Operation, forward: NextLink) => {
     const isClient = hasDirectives(['client'], operation.query);
 

--- a/packages/apollo-link-state/src/index.ts
+++ b/packages/apollo-link-state/src/index.ts
@@ -78,10 +78,10 @@ export const withClientState = ({ resolvers, defaults, cache }) => {
           const context = operation.getContext();
 
           // Add a writeData method to the cache
-          const cache: ApolloCacheClient = context.cache;
+          const contextCache: ApolloCacheClient = context.cache;
 
-          if (cache && !cache.writeData) {
-            addWriteDataToCache(cache);
+          if (contextCache && !contextCache.writeData) {
+            addWriteDataToCache(contextCache);
           }
 
           graphql(resolver, query, data, context, operation.variables).then(


### PR DESCRIPTION
- `withClientState()` now takes a config with `resolvers`, `defaults`, and `cache` properties
- If `defaults` & `cache` are passed in, `withClientState` will write the defaults to the cache with `cache.writeData`.
- Updated tests to reflect new API
- Added new tests for the initialization of `withClientState`