### PR TITLE
Always return null

### DIFF
--- a/packages/apollo-link-state/CHANGELOG.md
+++ b/packages/apollo-link-state/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change log
 
-### vNEXT
+### vNext
+- If a resolver doesn't have a return value, default to null
+
+### 0.3.0
 - BREAKING: Changed `withClientState` API to take a config object with `resolvers`, `defaults`, and `cache` properties: [#132](https://github.com/apollographql/apollo-link-state/pull/132)
 - Fix overriding fragment parent's __typename: [#131](https://github.com/apollographql/apollo-link-state/pull/131)
 

--- a/packages/apollo-link-state/package.json
+++ b/packages/apollo-link-state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-link-state",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "An easy way to manage local state with Apollo Link",
   "author": "James Baxley <james@meteor.com>",
   "license": "MIT",

--- a/packages/apollo-link-state/src/index.ts
+++ b/packages/apollo-link-state/src/index.ts
@@ -57,7 +57,7 @@ export const withClientState = (
         resolvers[(rootValue as any).__typename || type][
           info.resultKey || fieldName
         ];
-      if (resolve) return resolve(rootValue, args, context, info);
+      if (resolve) return resolve(rootValue, args, context, info) || null;
     };
 
     return new Observable(observer => {


### PR DESCRIPTION
GraphQL servers never return undefined, always null. We need to also return null from resolvers without a return value to avoid warnings in Apollo Client.