### PR TITLE
Fix resolver thrown-error-propagation

### DIFF
--- a/packages/apollo-link-state/src/__tests__/__snapshots__/advanced.ts.snap
+++ b/packages/apollo-link-state/src/__tests__/__snapshots__/advanced.ts.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[
+  `server and client state correctly propagates an error from a client-state resolver 1`
+] = `"Network error: Illegal Query Operation Occurred"`;
+
+exports[
+  `server and client state correctly propagates an error from a client-state resolver 2`
+] = `"Network error: Illegal Mutation Operation Occurred"`;

--- a/packages/apollo-link-state/src/__tests__/advanced.ts
+++ b/packages/apollo-link-state/src/__tests__/advanced.ts
@@ -156,6 +156,9 @@ describe('server and client state', () => {
       done.fail('Should have thrown!');
     } catch (e) {
       // Test Passed!
+      expect(() => {
+        throw e;
+      }).toThrowErrorMatchingSnapshot();
     }
 
     try {
@@ -163,6 +166,9 @@ describe('server and client state', () => {
       done.fail('Should have thrown!');
     } catch (e) {
       // Test Passed!
+      expect(() => {
+        throw e;
+      }).toThrowErrorMatchingSnapshot();
     }
 
     done();

--- a/packages/apollo-link-state/src/index.ts
+++ b/packages/apollo-link-state/src/index.ts
@@ -69,6 +69,8 @@ export const withClientState = (
               data: {},
             });
 
+      const observerErrorHandler = observer.error.bind(observer);
+
       const sub = obs.subscribe({
         next: ({ data, errors }) => {
           const context = operation.getContext();
@@ -80,17 +82,17 @@ export const withClientState = (
             addWriteDataToCache(contextCache);
           }
 
-          graphql(resolver, query, data, context, operation.variables).then(
-            nextData => {
+          graphql(resolver, query, data, context, operation.variables)
+            .then(nextData => {
               observer.next({
                 data: nextData,
                 errors,
               });
               observer.complete();
-            },
-          );
+            })
+            .catch(observerErrorHandler);
         },
-        error: observer.error.bind(observer),
+        error: observerErrorHandler,
       });
 
       return () => {


### PR DESCRIPTION
The subscription for graphql calls was producing a promise that didn’t have errors caught. This meant that when an apollo-link-state resolver threw an error, that error was uncatchable in Jest, and that means that users can’t validate API failures when they occur.

- This catches errors thrown in resolvers, and funnels them into the `observer.error` handler.
- Adds a unit test showing how to try/catch and receive the error being produced by the resolver.

_**Note**:_ -- This may be the wrong way to propagate errors, and if so, I'd love to understand the right way. Thanks!