### PR TITLE
Support Aliases in @client-tagged queries

### DIFF
--- a/packages/apollo-link-state/src/__tests__/index.ts
+++ b/packages/apollo-link-state/src/__tests__/index.ts
@@ -15,6 +15,14 @@ const query = gql`
   }
 `;
 
+const aliasedQuery = gql`
+  query Test {
+    fie: foo @client {
+      bar
+    }
+  }
+`;
+
 const doubleQuery = gql`
   query Double {
     foo @client {
@@ -191,6 +199,25 @@ it('runs resolvers for missing client queries with aliased field', done => {
   });
   execute(client.concat(sample), { query }).subscribe(({ data }) => {
     expect(data).toEqual({ foo: { bar: true }, baz: { foo: true } });
+    done();
+  }, done.fail);
+});
+
+it('runs resolvers for client queries when aliases are in use on the @client-tagged node', done => {
+  const client = withClientState({
+    resolvers: {
+      Query: {
+        foo: () => ({ bar: true }),
+        fie: () => {
+          done.fail(
+            "Called the resolver using the alias' name, instead of the correct resolver name.",
+          );
+        },
+      },
+    },
+  });
+  execute(client, { query: aliasedQuery }).subscribe(({ data }) => {
+    expect(data).toEqual({ fie: { bar: true } });
     done();
   }, done.fail);
 });

--- a/packages/apollo-link-state/src/index.ts
+++ b/packages/apollo-link-state/src/index.ts
@@ -53,10 +53,8 @@ export const withClientState = (
       if (fieldValue !== undefined) return fieldValue;
 
       // Look for the field in the custom resolver map
-      const resolve =
-        resolvers[(rootValue as any).__typename || type][
-          info.resultKey || fieldName
-        ];
+      const resolverMap = resolvers[(rootValue as any).__typename || type];
+      const resolve = resolverMap[fieldName] || resolverMap[info.resultKey];
       if (resolve) return resolve(rootValue, args, context, info);
     };
 

--- a/packages/apollo-link-state/src/index.ts
+++ b/packages/apollo-link-state/src/index.ts
@@ -54,7 +54,7 @@ export const withClientState = (
 
       // Look for the field in the custom resolver map
       const resolverMap = resolvers[(rootValue as any).__typename || type];
-      const resolve = resolverMap[fieldName] || resolverMap[info.resultKey];
+      const resolve = resolverMap[fieldName];
       if (resolve) return resolve(rootValue, args, context, info);
     };
 


### PR DESCRIPTION
This PR fixes #144 -- It looks up the resolver to use by doing the correct fallback pattern, instead of looking up by the alias, it looks up by the true-name of a given node.

This also adds a test that demonstrates the problem.