### PR TITLE
Make config’s cache Type more accepting

### DIFF
--- a/packages/apollo-link-state/src/__tests__/index.ts
+++ b/packages/apollo-link-state/src/__tests__/index.ts
@@ -5,6 +5,7 @@ import { print } from 'graphql/language/printer';
 import { parse } from 'graphql/language/parser';
 
 import { withClientState } from '../';
+import { InMemoryCache } from 'apollo-cache-inmemory';
 
 // const sleep = ms => new Promise(s => setTimeout(s, ms));
 const query = gql`
@@ -51,6 +52,14 @@ const resolvers = {
     foo: () => ({ bar: true }),
   },
 };
+
+//#region Configuration Typings Test
+// No other unit tests were configuring a link like the docs were, and that lead
+// to an issue when calling code was using TypeScript strictly. The contained
+// line of code was sufficient to expose this error.
+withClientState({ cache: new InMemoryCache(), resolvers });
+// This functions as a "Test" that the TypeScript types work as intended.
+//#endregion Configuration Typings Test
 
 it('strips out the client directive and does not call other links if no more fields', done => {
   const nextLink = new ApolloLink(operation => {

--- a/packages/apollo-link-state/src/utils.ts
+++ b/packages/apollo-link-state/src/utils.ts
@@ -13,7 +13,11 @@ import {
   removeDirectivesFromDocument,
 } from 'apollo-utilities';
 
-import { ApolloCacheClient, WriteDataArgs } from './';
+import {
+  ApolloCacheClient,
+  ApolloCacheClient_Writeable,
+  WriteDataArgs,
+} from './';
 
 const connectionRemoveConfig = {
   test: (directive: DirectiveNode) => directive.name.value === 'client',
@@ -132,7 +136,10 @@ function selectionSetFromObj(obj) {
 }
 
 export function addWriteDataToCache(cache: ApolloCacheClient) {
-  cache.writeData = ({ id, data }: WriteDataArgs) => {
+  (cache as ApolloCacheClient_Writeable).writeData = ({
+    id,
+    data,
+  }: WriteDataArgs) => {
     if (id) {
       let typenameResult = null;
       // Since we can't use fragments without having a typename in the store,


### PR DESCRIPTION
Fixes #143 by making the input type for the `withClientState(` slightly more accepting to explicitly accept caches that don't have a writeData method yet. -- The code was already monkey patching this method in, so javascript clients weren't affected, but if consumers used TypeScript they were getting an error.