### PR TITLE
Fix aliases for default resolvers for @client queries

### DIFF
--- a/packages/apollo-link-state/src/__tests__/client.ts
+++ b/packages/apollo-link-state/src/__tests__/client.ts
@@ -307,7 +307,9 @@ describe('cache usage', () => {
     });
 
     return client.query({ query }).then(({ data }) => {
-      expect({ ...data }).toEqual({ fie: { bar: 'yo', __typename: 'Foo' } });
+      expect({ ...data }).toMatchObject({
+        fie: { bar: 'yo', __typename: 'Foo' },
+      });
     });
   });
 });

--- a/packages/apollo-link-state/src/__tests__/client.ts
+++ b/packages/apollo-link-state/src/__tests__/client.ts
@@ -280,6 +280,36 @@ describe('cache usage', () => {
         expect({ ...data }).toEqual({ field: '1234' });
       });
   });
+
+  it('runs default resolvers for aliased fields tagged with @client', () => {
+    const query = gql`
+      {
+        fie: foo @client {
+          bar
+        }
+      }
+    `;
+
+    const cache = new InMemoryCache();
+
+    const client = new ApolloClient({
+      cache,
+      link: withClientState({
+        cache,
+        resolvers: {},
+        defaults: {
+          foo: {
+            bar: 'yo',
+            __typename: 'Foo',
+          },
+        },
+      }),
+    });
+
+    return client.query({ query }).then(({ data }) => {
+      expect({ ...data }).toEqual({ fie: { bar: 'yo', __typename: 'Foo' } });
+    });
+  });
 });
 
 describe('sample usage', () => {

--- a/packages/apollo-link-state/src/__tests__/index.ts
+++ b/packages/apollo-link-state/src/__tests__/index.ts
@@ -192,7 +192,7 @@ it('runs resolvers for missing client queries with aliased field', done => {
     }
   `;
   const sample = new ApolloLink(() =>
-    Observable.of({ data: { baz: { foo: true } } }),
+    Observable.of({ data: { bar: { foo: true } } }),
   );
   const client = withClientState({
     resolvers,

--- a/packages/apollo-link-state/src/index.ts
+++ b/packages/apollo-link-state/src/index.ts
@@ -49,7 +49,7 @@ export const withClientState = (
       ) || 'Query';
 
     const resolver = (fieldName, rootValue = {}, args, context, info) => {
-      const fieldValue = rootValue[info.resultKey || fieldName];
+      const fieldValue = rootValue[fieldName];
       if (fieldValue !== undefined) return fieldValue;
 
       // Look for the field in the custom resolver map


### PR DESCRIPTION
We had a broken test that was giving us a false positive! Now, aliases work for default resolvers on `@client` tagged queries.