### PR TITLE
Tweak withClientState signature to work around typescript bug

### DIFF
--- a/packages/apollo-link-state/src/index.ts
+++ b/packages/apollo-link-state/src/index.ts
@@ -21,8 +21,9 @@ export type ClientStateConfig = {
 };
 
 export const withClientState = (
-  { resolvers, defaults, cache }: ClientStateConfig = { resolvers: {} },
+  clientStateConfig: ClientStateConfig = { resolvers: {} },
 ) => {
+  const { resolvers, defaults, cache } = clientStateConfig;
   if (cache && defaults) {
     cache.writeData({ data: defaults });
   }


### PR DESCRIPTION
Resolves #158

This is a non-ideal fix for #158, related on a TypeScript issue that should be fixed, but apparently is not (Microsoft/TypeScript/issues/8681). The relevent comment in that issue is [this one](https://github.com/Microsoft/TypeScript/issues/8681#issuecomment-220400209)

The typescript code in apollo-link-state is perfectly fine and would work as is, but the generated type definition, after compilation is:

`export declare const withClientState: ({resolvers, defaults, cache}?: ClientStateConfig)`

With strict null enabled, you'll get an error message because it is impossible to destructure the fields when the object is nullable (because of the `?` after the curly brace). At runtime this isn't an issue since withClientState's argument has a default value.

This PR changes the signature to "trick" the compiler a little: by doing the destructuring inside of the function,  the generated `.d.ts` will not have destructuring, and the problem goes away.

It's not great to have to do this, but typescript with strict null is sooooooooo good, it's hard to give up :)

I'll follow up by opening a new issue on the typescript repo, but history has shown issues like that can take a long time to get fixed there.