### PR TITLE
Point doc-link at official docs instead of GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ npm install apollo-link-state --save
 ```
 
 The rest of the instructions assume that you have already [set up Apollo
-Client](https://www.apollographql.com/docs/react/basics/setup.html#installation) in your application. After
+Client](https://www.apollographql.com/docs/react/basics/setup.html#creating-client) in your application. After
 you install the package, you can create your state link by calling
 `withClientState` and passing in a resolver map. A resolver map describes how to
 retrieve and update your local data.


### PR DESCRIPTION
Context: https://github.com/apollographql/apollo-link-state/pull/166#issuecomment-356004501