### PR TITLE
Fix a typo in the documentation 

### DIFF
--- a/examples/todo/README.md
+++ b/examples/todo/README.md
@@ -4,7 +4,7 @@ Todo App with Apollo Client
 ## What?!
 This is a take on the classic [Redux Todo App](https://github.com/reactjs/redux/tree/master/examples/todos) but written to use Apollo's new architecture showcasing local state.
 
-Yes, this is overkill for a todo app, please don't use this is all you are doing is managing a few local state pieces. However, it can serve as a starting point for managing local state using Apollo for larger applications
+Yes, this is overkill for a todo app, please don't use this if all you are doing is managing a few local state pieces. However, it can serve as a starting point for managing local state using Apollo for larger applications
 
 ### Installation
 ```


### PR DESCRIPTION
This is a very small fix... I just corrected a typo in the README for the todos example.  