### PR TITLE
[client schemas] Added typeDefs to config, added @client directive to context

### DIFF
--- a/packages/apollo-link-state/src/__tests__/__snapshots__/index.ts.snap
+++ b/packages/apollo-link-state/src/__tests__/__snapshots__/index.ts.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`passes a query on to the next link 1`] = `
+Object {
+  "directives": "directive @client on FIELD",
+}
+`;

--- a/packages/apollo-link-state/src/__tests__/__snapshots__/index.ts.snap
+++ b/packages/apollo-link-state/src/__tests__/__snapshots__/index.ts.snap
@@ -1,7 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`passes a query on to the next link 1`] = `
-Object {
-  "directives": "directive @client on FIELD",
-}
-`;
+exports[`passes a query on to the next link 1`] = `Object {}`;

--- a/packages/apollo-link-state/src/__tests__/__snapshots__/initialization.ts.snap
+++ b/packages/apollo-link-state/src/__tests__/__snapshots__/initialization.ts.snap
@@ -3,7 +3,9 @@
 exports[
   `initialization adds a schema string in SDL format to the context as definition if typeDefs are passed in 1`
 ] = `
-"
+Array [
+  Object {
+    "definition": "
     type Todo {
       id: String
       message: String!
@@ -12,19 +14,18 @@ exports[
     type Query {
       todo(id: String!): Todo
     }
-  "
-`;
-
-exports[`initialization adds the @client directive to the context 1`] = `
-Object {
-  "directives": "directive @client on FIELD",
-}
+  ",
+    "directives": "directive @client on FIELD",
+  },
+]
 `;
 
 exports[
   `initialization concatenates schema strings if typeDefs are passed in as an array 1`
 ] = `
-"type Todo {
+Array [
+  Object {
+    "definition": "type Todo {
       id: String
       message: String!
     }
@@ -35,16 +36,10 @@ exports[
 type Foo {
         foo: String!
         bar: String
-      }"
-`;
-
-exports[
-  `initialization does not step on existing directives on the context 1`
-] = `
-Object {
-  "directives": "directive @rest on FIELD
-directive @client on FIELD",
-}
+      }",
+    "directives": "directive @client on FIELD",
+  },
+]
 `;
 
 exports[`initialization writes defaults to the cache upon initialization 1`] = `

--- a/packages/apollo-link-state/src/__tests__/__snapshots__/initialization.ts.snap
+++ b/packages/apollo-link-state/src/__tests__/__snapshots__/initialization.ts.snap
@@ -1,5 +1,52 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[
+  `initialization adds a schema string in SDL format to the context as definition if typeDefs are passed in 1`
+] = `
+"
+    type Todo {
+      id: String
+      message: String!
+    }
+
+    type Query {
+      todo(id: String!): Todo
+    }
+  "
+`;
+
+exports[`initialization adds the @client directive to the context 1`] = `
+Object {
+  "directives": "directive @client on FIELD",
+}
+`;
+
+exports[
+  `initialization concatenates schema strings if typeDefs are passed in as an array 1`
+] = `
+"type Todo {
+      id: String
+      message: String!
+    }
+
+    type Query {
+      todo(id: String!): Todo
+    }
+type Foo {
+        foo: String!
+        bar: String
+      }"
+`;
+
+exports[
+  `initialization does not step on existing directives on the context 1`
+] = `
+Object {
+  "directives": "directive @rest on FIELD
+directive @client on FIELD",
+}
+`;
+
 exports[`initialization writes defaults to the cache upon initialization 1`] = `
 Object {
   "$ROOT_QUERY.foo": Object {

--- a/packages/apollo-link-state/src/__tests__/index.ts
+++ b/packages/apollo-link-state/src/__tests__/index.ts
@@ -75,7 +75,7 @@ it('strips out the client directive and does not call other links if no more fie
 
 it('passes a query on to the next link', done => {
   const nextLink = new ApolloLink(operation => {
-    expect(operation.getContext()).toEqual({});
+    expect(operation.getContext()).toMatchSnapshot();
     expect(print(operation.query)).toEqual(
       print(gql`
         query Mixed {

--- a/packages/apollo-link-state/src/__tests__/initialization.ts
+++ b/packages/apollo-link-state/src/__tests__/initialization.ts
@@ -1,12 +1,39 @@
 import gql from 'graphql-tag';
 import { ApolloClient } from 'apollo-client';
 import { InMemoryCache } from 'apollo-cache-inmemory';
+import { Observable, ApolloLink, execute } from 'apollo-link';
 
 import { withClientState } from '../';
 
 describe('initialization', () => {
   const resolvers = { Query: { foo: () => ({ bar: true }) } };
   const defaults = { foo: { bar: false, __typename: 'Bar' } };
+  const query = gql`
+    {
+      foo @client {
+        bar
+      }
+    }
+  `;
+
+  const remoteQuery = gql`
+    {
+      foo {
+        bar
+      }
+    }
+  `;
+
+  const typeDefs = `
+    type Todo {
+      id: String
+      message: String!
+    }
+
+    type Query {
+      todo(id: String!): Todo
+    }
+  `;
 
   it('writes defaults to the cache upon initialization', () => {
     const cache = new InMemoryCache();
@@ -25,14 +52,6 @@ describe('initialization', () => {
       link: withClientState({ cache, resolvers, defaults }),
     });
 
-    const query = gql`
-      {
-        foo @client {
-          bar
-        }
-      }
-    `;
-
     client
       .query({ query })
       .then(({ data }) => {
@@ -40,5 +59,82 @@ describe('initialization', () => {
         expect(data.foo.bar).toEqual(false);
       })
       .catch(e => console.error(e));
+  });
+
+  it('adds a schema string in SDL format to the context as definition if typeDefs are passed in', done => {
+    const nextLink = new ApolloLink(operation => {
+      const { definition } = operation.getContext();
+      expect(definition).toMatchSnapshot();
+      return Observable.of({
+        data: { foo: { bar: true, __typename: 'Bar' } },
+      });
+    });
+
+    const client = withClientState({ resolvers, defaults, typeDefs });
+
+    execute(client.concat(nextLink), {
+      query: remoteQuery,
+    }).subscribe(() => done(), done.fail);
+  });
+
+  it('concatenates schema strings if typeDefs are passed in as an array', done => {
+    const anotherSchema = `
+      type Foo {
+        foo: String!
+        bar: String
+      }
+    `;
+
+    const nextLink = new ApolloLink(operation => {
+      const { definition } = operation.getContext();
+      expect(definition).toMatchSnapshot();
+      return Observable.of({
+        data: { foo: { bar: true, __typename: 'Bar' } },
+      });
+    });
+
+    const client = withClientState({
+      resolvers,
+      defaults,
+      typeDefs: [typeDefs, anotherSchema],
+    });
+
+    execute(client.concat(nextLink), {
+      query: remoteQuery,
+    }).subscribe(() => done(), done.fail);
+  });
+
+  it('adds the @client directive to the context', done => {
+    const nextLink = new ApolloLink(operation => {
+      expect(operation.getContext()).toMatchSnapshot();
+      return Observable.of({ data: { foo: { bar: true, __typename: 'Bar' } } });
+    });
+
+    const client = withClientState({ resolvers, defaults });
+
+    execute(client.concat(nextLink), {
+      query: remoteQuery,
+    }).subscribe(() => done(), done.fail);
+  });
+
+  it('does not step on existing directives on the context', done => {
+    const restLink = new ApolloLink((operation, forward) => {
+      operation.setContext({
+        directives: 'directive @rest on FIELD',
+      });
+
+      return forward(operation);
+    });
+
+    const nextLink = new ApolloLink(operation => {
+      expect(operation.getContext()).toMatchSnapshot();
+      return Observable.of({ data: { foo: { bar: true, __typename: 'Bar' } } });
+    });
+
+    const client = withClientState({ resolvers, defaults });
+
+    execute(ApolloLink.from([restLink, client, nextLink]), {
+      query: remoteQuery,
+    }).subscribe(() => done(), done.fail);
   });
 });

--- a/packages/apollo-link-state/src/__tests__/initialization.ts
+++ b/packages/apollo-link-state/src/__tests__/initialization.ts
@@ -63,8 +63,8 @@ describe('initialization', () => {
 
   it('adds a schema string in SDL format to the context as definition if typeDefs are passed in', done => {
     const nextLink = new ApolloLink(operation => {
-      const { definition } = operation.getContext();
-      expect(definition).toMatchSnapshot();
+      const { schemas } = operation.getContext();
+      expect(schemas).toMatchSnapshot();
       return Observable.of({
         data: { foo: { bar: true, __typename: 'Bar' } },
       });
@@ -86,8 +86,8 @@ describe('initialization', () => {
     `;
 
     const nextLink = new ApolloLink(operation => {
-      const { definition } = operation.getContext();
-      expect(definition).toMatchSnapshot();
+      const { schemas } = operation.getContext();
+      expect(schemas).toMatchSnapshot();
       return Observable.of({
         data: { foo: { bar: true, __typename: 'Bar' } },
       });
@@ -100,40 +100,6 @@ describe('initialization', () => {
     });
 
     execute(client.concat(nextLink), {
-      query: remoteQuery,
-    }).subscribe(() => done(), done.fail);
-  });
-
-  it('adds the @client directive to the context', done => {
-    const nextLink = new ApolloLink(operation => {
-      expect(operation.getContext()).toMatchSnapshot();
-      return Observable.of({ data: { foo: { bar: true, __typename: 'Bar' } } });
-    });
-
-    const client = withClientState({ resolvers, defaults });
-
-    execute(client.concat(nextLink), {
-      query: remoteQuery,
-    }).subscribe(() => done(), done.fail);
-  });
-
-  it('does not step on existing directives on the context', done => {
-    const restLink = new ApolloLink((operation, forward) => {
-      operation.setContext({
-        directives: 'directive @rest on FIELD',
-      });
-
-      return forward(operation);
-    });
-
-    const nextLink = new ApolloLink(operation => {
-      expect(operation.getContext()).toMatchSnapshot();
-      return Observable.of({ data: { foo: { bar: true, __typename: 'Bar' } } });
-    });
-
-    const client = withClientState({ resolvers, defaults });
-
-    execute(ApolloLink.from([restLink, client, nextLink]), {
       query: remoteQuery,
     }).subscribe(() => done(), done.fail);
   });


### PR DESCRIPTION
- Added `typeDefs` as a config property to `withClientState`. `typeDefs` either accepts a string in SDL format or an array of strings in SDL format, just like `graphql-tools`
- `typeDefs` are added to `context.definition`
- `@client` directive is added to `context.directives`