### PR TITLE
Add resolver checking to fix undefined bug and return defaults when no resolver present

### DIFF
--- a/packages/apollo-link-state/CHANGELOG.md
+++ b/packages/apollo-link-state/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change log
 
+### vNext
+- Return defaults when no Queries resolver is found and check for `resolverMap` [#202](https://github.com/apollographql/apollo-link-state/pull/202)
+
 ### 0.4.0
 - Change config destructuring to support TS strict mode [#165](https://github.com/apollographql/apollo-link-state/pull/165)
 - Add `typeDefs` config property for client-side schemas [#180](https://github.com/apollographql/apollo-link-state/pull/180)

--- a/packages/apollo-link-state/src/__tests__/client.ts
+++ b/packages/apollo-link-state/src/__tests__/client.ts
@@ -7,9 +7,6 @@ import { print } from 'graphql/language/printer';
 import { parse } from 'graphql/language/parser';
 
 import { withClientState } from '../';
-import { ApolloCache } from 'apollo-cache';
-import { QueryDocumentKeys } from 'graphql/language/visitor';
-import { check } from 'graphql-anywhere/lib/utilities';
 
 const makeTerminatingCheck = (done, body) => {
   return (...args) => {

--- a/packages/apollo-link-state/src/index.ts
+++ b/packages/apollo-link-state/src/index.ts
@@ -75,7 +75,7 @@ export const withClientState = (
 
         // Look for the field in the custom resolver map
         const resolverMap = resolvers[(rootValue as any).__typename || type];
-        if(resolverMap){
+        if (resolverMap) {
           const resolve = resolverMap[fieldName];
           if (resolve) return resolve(rootValue, args, context, info);
         }

--- a/packages/apollo-link-state/src/index.ts
+++ b/packages/apollo-link-state/src/index.ts
@@ -69,12 +69,17 @@ export const withClientState = (
 
       const resolver = (fieldName, rootValue = {}, args, context, info) => {
         const fieldValue = rootValue[fieldName];
+
+        //If fieldValue is defined, server returned a value
         if (fieldValue !== undefined) return fieldValue;
 
         // Look for the field in the custom resolver map
         const resolverMap = resolvers[(rootValue as any).__typename || type];
-        const resolve = resolverMap[fieldName];
-        if (resolve) return resolve(rootValue, args, context, info);
+        if(resolverMap){
+          const resolve = resolverMap[fieldName];
+          if (resolve) return resolve(rootValue, args, context, info);
+        }
+        return defaults[fieldName];
       };
 
       return new Observable(observer => {


### PR DESCRIPTION
This fixes #198 #194 in their current form. 

This PR adds a check for the presence of a `resolverMap`. The `Queries: () => ({})` getaround worked detailed in [this comment](https://github.com/apollographql/apollo-link-state/issues/156#issuecomment-355787466), since it created a value for `resolverMap`. For a client GraphQL queries that pulls directly from the cache([no resolver specified](https://github.com/apollographql/apollo-link-state/compare/reset-store-fix?expand=1#diff-9b211e831ad83aa5febe90562b1e1b1bR428)), a `resetStore` appears to cause no issues. A link-state [Query resolver](https://github.com/apollographql/apollo-link-state/compare/reset-store-fix?expand=1#diff-9b211e831ad83aa5febe90562b1e1b1bR485) that returns a raw value is also fine.

The unresolved issue is a Query resolver that attempts to pull from the cache after a `resetStore`. This is due to the ordering of `resetStore`: empties store, calls `broadcastQueries`(notifies the link-state resolver), then calls the `onResetStore` callbacks(writes link-state defaults). We need to either reorder `resetStore`(a "breaking" change, given that the order is not documented) or add another function, such as `onEmptyStore` that will be called any time the Apollo Cache is empty.