### PR TITLE
Fix TypeScript Sourcemaps & Codecov Line Mapping

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,13 @@
     }
   ],
   "jest": {
+    "globals": {
+      "ts-jest": {
+        "useBabelrc": false,
+        "mapCoverage": true
+      }
+    },
+    "mapCoverage": true,
     "transform": {
       ".(ts|tsx)": "<rootDir>/node_modules/ts-jest/preprocessor.js"
     }
@@ -45,6 +52,7 @@
   "pre-commit": "lint-staged",
   "dependencies": {},
   "devDependencies": {
+    "@types/jest": "22.1.x",
     "@types/zen-observable": "0.5.3",
     "bundlesize": "0.15.3",
     "codecov": "3.0.0",

--- a/packages/apollo-link-state/package.json
+++ b/packages/apollo-link-state/package.json
@@ -17,16 +17,19 @@
   },
   "homepage": "https://github.com/apollographql/apollo-link-state#readme",
   "scripts": {
-    "build:browser": "browserify ./lib/bundle.umd.js -o=./lib/bundle.js --i apollo-link --i apollo-utilities --i graphql-anywhere && npm run minify:browser",
+    "build:browser":
+      "browserify ./lib/bundle.umd.js -o=./lib/bundle.js --i apollo-link --i apollo-utilities --i graphql-anywhere && npm run minify:browser",
     "build": "tsc -p .",
     "bundle": "rollup -c",
     "clean": "rimraf lib/* && rimraf coverage/*",
     "filesize": "npm run build && npm run build:browser && bundlesize",
     "prelint": "npm run lint-fix",
-    "lint-fix": "prettier --trailing-comma all --single-quote --write \"src/**/*.{j,t}s*\"",
+    "lint-fix":
+      "prettier --trailing-comma all --single-quote --write \"src/**/*.{j,t}s*\"",
     "lint": "tslint --type-check -p tsconfig.json -c tslint.json src/*.ts",
     "lint-staged": "lint-staged",
-    "minify:browser": "uglifyjs -c -m -o ./lib/bundle.min.js -- ./lib/bundle.js",
+    "minify:browser":
+      "uglifyjs -c -m -o ./lib/bundle.min.js -- ./lib/bundle.js",
     "postbuild": "npm run bundle",
     "prebuild": "npm run clean",
     "prepublishOnly": "npm run clean && npm run build",
@@ -46,7 +49,7 @@
   },
   "devDependencies": {
     "@types/graphql": "0.11.5",
-    "@types/jest": "21.1.5",
+    "@types/jest": "22.1.x",
     "apollo-cache-inmemory": "^1.1.5",
     "apollo-client": "^2.2.0",
     "apollo-link": "^1.0.0",
@@ -61,23 +64,21 @@
     "pre-commit": "1.2.2",
     "prettier": "1.7.4",
     "rimraf": "2.6.1",
-    "rollup": "^0.55.3",
+    "rollup": "0.56.x",
+    "rollup-plugin-local-resolve": "1.0.x",
+    "rollup-plugin-sourcemaps": "0.4.x",
     "ts-jest": "21.1.4",
     "tslint": "5.8.0",
     "typescript": "2.5.1",
     "uglify-js": "3.1.5"
   },
   "jest": {
+    "mapCoverage": true,
     "transform": {
       ".(ts|tsx)": "<rootDir>/node_modules/ts-jest/preprocessor.js"
     },
     "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
-    "moduleFileExtensions": [
-      "ts",
-      "tsx",
-      "js",
-      "json"
-    ]
+    "moduleFileExtensions": ["ts", "tsx", "js", "json"]
   },
   "dependencies": {
     "apollo-utilities": "^1.0.6",
@@ -92,10 +93,7 @@
       "prettier --trailing-comma all --single-quote --write",
       "git add"
     ],
-    "*.json*": [
-      "prettier --write",
-      "git add"
-    ]
+    "*.json*": ["prettier --write", "git add"]
   },
   "pre-commit": "lint-staged"
 }

--- a/packages/apollo-link-state/rollup.config.js
+++ b/packages/apollo-link-state/rollup.config.js
@@ -1,3 +1,6 @@
+import resolve from 'rollup-plugin-local-resolve';
+import sourcemaps from 'rollup-plugin-sourcemaps';
+
 const globals = {
   // Apollo
   'apollo-client': 'apollo.core',
@@ -5,7 +8,7 @@ const globals = {
   'apollo-link': 'apolloLink.core',
   'apollo-utilities': 'apollo.utilities',
 
-  'graphql-anywhere/lib/async': 'async',
+  'graphql-anywhere/lib/async': 'graphqlAnywhere.async',
 };
 
 export default {
@@ -13,14 +16,15 @@ export default {
   output: {
     file: 'lib/bundle.umd.js',
     format: 'umd',
-    name: 'errorLink',
+    name: 'apolloLink.error',
     exports: 'named',
     sourcemap: true,
     globals,
   },
   external: Object.keys(globals),
   onwarn,
-}
+  plugins: [resolve(), sourcemaps()],
+};
 
 function onwarn(message) {
   const suppressed = ['UNRESOLVED_IMPORT', 'THIS_IS_UNDEFINED'];

--- a/packages/apollo-link-state/rollup.config.js
+++ b/packages/apollo-link-state/rollup.config.js
@@ -16,7 +16,7 @@ export default {
   output: {
     file: 'lib/bundle.umd.js',
     format: 'umd',
-    name: 'apolloLink.error',
+    name: 'apolloLink.state',
     exports: 'named',
     sourcemap: true,
     globals,


### PR DESCRIPTION
Currently, when you run jest, the [codecov.io](https://codecov.io/gh/apollographql/apollo-link-state/src/8d3d95313afa5e6c333c8325f2f73436d87db701/packages/apollo-link-state/src/index.ts) reports suggest that lines aren't properly being sourcemapped.

Based on:

- https://github.com/apollographql/apollo-client/pull/3042
- https://github.com/apollographql/apollo-link-rest/issues/76
- https://github.com/apollographql/apollo-link-rest/pull/78
- https://github.com/apollographql/apollo-link-rest/pull/79