### PR TITLE
Remove message about Object.assign (no longer needed)

### DIFF
--- a/examples/async/src/resolvers/index.js
+++ b/examples/async/src/resolvers/index.js
@@ -20,21 +20,10 @@ export default {
           maximumAge,
         });
 
-        /*
-        The object returned from getCurrentPosition has read only properties.
-        Copying read-only properties is blocked by Object.assign.
-        Copying read-only properties is not blocked by the spread operator (according to the spec),
-        Since Babel compiles the spread operator to Object.assign, we can't use it here until the transform is spec-compliant.
-        https://github.com/babel/babel/pull/7034
-        */
-
         const { coords, timestamp } = data;
         return {
           coords: {
-            latitude: coords.latitude,
-            longitude: coords.longitude,
-            altitude: coords.altitude,
-            accuracy: coords.accuracy,
+            ...coords,
             __typename: 'Coordinates',
           },
           timestamp,


### PR DESCRIPTION
Object spread fixed in babel and merged as of 17 February. See here: https://github.com/babel/babel/pull/7034

⚠️ I couldn't test this as the example doesn't work in my browser (Geolocation issue) so please check before merging. Apologies if there's an issue with it.