### PR TITLE
apollo link state with apollo boost

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,32 @@ const WrappedComponent = graphql(GET_ARTICLES, {
 
 For more detailed examples, plus in-depth explanations of resolvers, defaults, and more, please check out our official [docs page](https://www.apollographql.com/docs/link/links/state.html).
 
+<h2 id="local-development">With Apollo Boost</h2>
+
+If you are using `apollo-boost`, it already includes `apollo-link-state` underneath the hood for you.
+Instead of passing the `link` property when instantiating Apollo Client, you pass in `clientState`.
+
+```js
+import ApolloClient from 'apollo-boost';
+
+const client = new ApolloClient({
+  clientState: {
+    defaults: {
+      isConnected: true
+    },
+    resolvers: {
+      Mutation: {
+        updateNetworkStatus: (_, { isConnected }, { cache }) => {
+          cache.writeData({ data: { isConnected }});
+          return null;
+        }
+      }
+    }
+  }
+});
+
+```
+
 <h2 id="local-development">Local Development</h2>
 
 If you're setting up for local development, and you want to integrate a local


### PR DESCRIPTION
- [x] docs

I'm not sure if this is the right place to update the docs, but I think it would be helpful to let users know the existence of `apollo-boost` and how it changes how `apollo-link-state` is used.