### PR TITLE
Add Support for nested GraphQL aliased fields

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "trailingComma": "all",
+  "singleQuote": true
+}

--- a/packages/apollo-link-state/src/__tests__/aliases.ts
+++ b/packages/apollo-link-state/src/__tests__/aliases.ts
@@ -1,0 +1,99 @@
+import gql from 'graphql-tag';
+import { ApolloLink, execute, Observable } from 'apollo-link';
+import { ApolloClient } from 'apollo-client';
+import { InMemoryCache } from 'apollo-cache-inmemory';
+
+import { withClientState } from '../';
+
+const resolvers = {
+  Query: {
+    foo: () => ({ bar: true }),
+  },
+};
+
+it('runs resolvers for missing client queries with aliased field', done => {
+  const query = gql`
+    query Aliased {
+      foo @client {
+        bar
+      }
+      baz: bar {
+        foo
+      }
+    }
+  `;
+  const sample = new ApolloLink(() =>
+    // The link-level takes care of the aliasing, so returns baz, not bar
+    Observable.of({ data: { baz: { foo: true } } }),
+  );
+  const clientLink = withClientState({
+    resolvers,
+  });
+  execute(clientLink.concat(sample), { query }).subscribe(({ data }) => {
+    try {
+      expect(data).toEqual({ foo: { bar: true }, baz: { foo: true } });
+    } catch (e) {
+      done.fail(e);
+    }
+    done();
+  }, done.fail);
+});
+
+it('runs resolvers for client queries when aliases are in use on the @client-tagged node', done => {
+  const aliasedQuery = gql`
+    query Test {
+      fie: foo @client {
+        bar
+      }
+    }
+  `;
+  const client = withClientState({
+    resolvers: {
+      Query: {
+        foo: () => ({ bar: true }),
+        fie: () => {
+          done.fail(
+            "Called the resolver using the alias' name, instead of the correct resolver name.",
+          );
+        },
+      },
+    },
+  });
+  execute(client, { query: aliasedQuery }).subscribe(({ data }) => {
+    expect(data).toEqual({ fie: { bar: true } });
+    done();
+  }, done.fail);
+});
+
+it('runs default resolvers for aliased fields tagged with @client', () => {
+  expect.assertions(1);
+  const query = gql`
+    {
+      fie: foo @client {
+        bar
+      }
+    }
+  `;
+
+  const cache = new InMemoryCache();
+
+  const client = new ApolloClient({
+    cache,
+    link: withClientState({
+      cache,
+      resolvers: {},
+      defaults: {
+        foo: {
+          bar: 'yo',
+          __typename: 'Foo',
+        },
+      },
+    }),
+  });
+
+  return client.query({ query }).then(({ data }) => {
+    expect({ ...data }).toMatchObject({
+      fie: { bar: 'yo', __typename: 'Foo' },
+    });
+  });
+});

--- a/packages/apollo-link-state/src/__tests__/client.ts
+++ b/packages/apollo-link-state/src/__tests__/client.ts
@@ -721,7 +721,7 @@ describe('cache usage', () => {
         complete: done.fail,
       });
 
-      client.resetStore() as Promise<null>;
+      client.resetStore();
     });
   });
 });

--- a/packages/apollo-link-state/src/__tests__/client.ts
+++ b/packages/apollo-link-state/src/__tests__/client.ts
@@ -313,38 +313,6 @@ describe('cache usage', () => {
       });
   });
 
-  it('runs default resolvers for aliased fields tagged with @client', () => {
-    const query = gql`
-      {
-        fie: foo @client {
-          bar
-        }
-      }
-    `;
-
-    const cache = new InMemoryCache();
-
-    const client = new ApolloClient({
-      cache,
-      link: withClientState({
-        cache,
-        resolvers: {},
-        defaults: {
-          foo: {
-            bar: 'yo',
-            __typename: 'Foo',
-          },
-        },
-      }),
-    });
-
-    return client.query({ query }).then(({ data }) => {
-      expect({ ...data }).toMatchObject({
-        fie: { bar: 'yo', __typename: 'Foo' },
-      });
-    });
-  });
-
   it('writeDefaults lets you write defaults to the cache after the store is reset', done => {
     const mutation = gql`
       mutation foo {

--- a/packages/apollo-link-state/src/__tests__/index.ts
+++ b/packages/apollo-link-state/src/__tests__/index.ts
@@ -15,14 +15,6 @@ const query = gql`
   }
 `;
 
-const aliasedQuery = gql`
-  query Test {
-    fie: foo @client {
-      bar
-    }
-  }
-`;
-
 const doubleQuery = gql`
   query Double {
     foo @client {
@@ -180,53 +172,6 @@ it('runs resolvers for missing client queries with variables', done => {
   });
   execute(client, { query, variables: { id: 1 } }).subscribe(({ data }) => {
     expect(data).toEqual({ foo: { bar: 1 } });
-    done();
-  }, done.fail);
-});
-
-it('runs resolvers for missing client queries with aliased field', done => {
-  const query = gql`
-    query Aliased {
-      foo @client {
-        bar
-      }
-      baz: bar {
-        foo
-      }
-    }
-  `;
-  const sample = new ApolloLink(() =>
-    //The server takes care of the aliasing, so returns baz, not bar
-    Observable.of({ data: { baz: { foo: true } } }),
-  );
-  const client = withClientState({
-    resolvers,
-  });
-  execute(client.concat(sample), { query }).subscribe(({ data }) => {
-    try {
-      expect(data).toEqual({ foo: { bar: true }, baz: { foo: true } });
-    } catch (e) {
-      done.fail(e);
-    }
-    done();
-  }, done.fail);
-});
-
-it('runs resolvers for client queries when aliases are in use on the @client-tagged node', done => {
-  const client = withClientState({
-    resolvers: {
-      Query: {
-        foo: () => ({ bar: true }),
-        fie: () => {
-          done.fail(
-            "Called the resolver using the alias' name, instead of the correct resolver name.",
-          );
-        },
-      },
-    },
-  });
-  execute(client, { query: aliasedQuery }).subscribe(({ data }) => {
-    expect(data).toEqual({ fie: { bar: true } });
     done();
   }, done.fail);
 });


### PR DESCRIPTION
Turns out that GraphQL Aliases were only partially supported. This PR adds a test that proves the GraphQL aliases weren't working by adding a more specific test that demonstrates it further.

There might be more crazy scenarios that this doesn't fully cover (the interaction between other link-data and how aliases work exactly is pretty challenging to understand), so this is just another baby step in the right direction.

Related: https://github.com/apollographql/apollo-link-rest/pull/113