### PR TITLE
Add zen observable types as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,10 +50,11 @@
     "*.json*": ["prettier --write", "git add"]
   },
   "pre-commit": "lint-staged",
-  "dependencies": {},
+  "dependencies": {
+    "@types/zen-observable": "0.5.3"
+  },
   "devDependencies": {
     "@types/jest": "22.1.x",
-    "@types/zen-observable": "0.5.3",
     "bundlesize": "0.15.3",
     "codecov": "3.0.0",
     "danger": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "*.json*": ["prettier --write", "git add"]
   },
   "pre-commit": "lint-staged",
-  "dependencies": {
+  "peerDependencies": {
     "@types/zen-observable": "0.5.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Making this change allows me to import `apollo-link-state` with TypeScript. Otherwise I get this error:

```
Failed to compile.

[at-loader] ./node_modules/apollo-link-state/lib/index.d.ts:1:23 
    TS2688: Cannot find type definition file for 'zen-observable'.
```

Looks like this has been an issue in other apollo client projects and this is the solution that was used.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [x] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->