### PR TITLE
Allow to provide resolvers via function

### DIFF
--- a/packages/apollo-link-state/CHANGELOG.md
+++ b/packages/apollo-link-state/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change log
 
+### vNEXT
+- Allow to provide resolvers via function
+
 ### 0.4.1
 - Return defaults when no Queries resolver is found and check for `resolverMap` [#202](https://github.com/apollographql/apollo-link-state/pull/202)
 - Fix for merging local & remote data not part of same selection set [#193](https://github.com/apollographql/apollo-link-state/pull/193)

--- a/packages/apollo-link-state/src/__tests__/index.ts
+++ b/packages/apollo-link-state/src/__tests__/index.ts
@@ -2,7 +2,6 @@ import gql from 'graphql-tag';
 import { ApolloLink, execute, Observable } from 'apollo-link';
 
 import { print } from 'graphql/language/printer';
-import { parse } from 'graphql/language/parser';
 
 import { withClientState } from '../';
 
@@ -11,17 +10,6 @@ const query = gql`
   query Test {
     foo @client {
       bar
-    }
-  }
-`;
-
-const doubleQuery = gql`
-  query Double {
-    foo @client {
-      bar
-    }
-    bar @client {
-      foo
     }
   }
 `;
@@ -36,15 +24,6 @@ const mixedQuery = gql`
     }
   }
 `;
-
-const data = {
-  foo: { bar: true },
-};
-
-const doubleData = {
-  foo: { bar: true },
-  bar: { foo: false },
-};
 
 const resolvers = {
   Query: {
@@ -197,5 +176,43 @@ it('passes context to client resolvers', done => {
   execute(client, { query, context: { id: 1 } }).subscribe(({ data }) => {
     expect(data).toEqual({ foo: { bar: 1 } });
     done();
+  }, done.fail);
+});
+
+it('calls resolvers on each request if the prop is a function', done => {
+  const query = gql`
+    query WithContext {
+      foo @client {
+        bar
+      }
+    }
+  `;
+  const resolversSpy = jest.fn();
+  const resolvers = () => {
+    resolversSpy();
+    return {
+      Query: {
+        foo: () => ({ __typename: 'Foo' }),
+      },
+      Foo: {
+        bar: () => 1,
+      },
+    };
+  };
+
+  const client = withClientState({
+    resolvers,
+  });
+
+  // once
+  execute(client, { query }).subscribe(({ data }) => {
+    expect(data).toEqual({ foo: { bar: 1 } });
+
+    // twice
+    execute(client, { query }).subscribe(({ data }) => {
+      expect(data).toEqual({ foo: { bar: 1 } });
+      expect(resolversSpy).toHaveBeenCalledTimes(2);
+      done();
+    }, done.fail);
   }, done.fail);
 });

--- a/packages/apollo-link-state/src/index.ts
+++ b/packages/apollo-link-state/src/index.ts
@@ -20,7 +20,7 @@ const capitalizeFirstLetter = str => str.charAt(0).toUpperCase() + str.slice(1);
 
 export type ClientStateConfig = {
   cache?: ApolloCache<any>;
-  resolvers: any;
+  resolvers: any | (() => any);
   defaults?: any;
   typeDefs?: string | string[];
   fragmentMatcher?: FragmentMatcher;
@@ -29,13 +29,7 @@ export type ClientStateConfig = {
 export const withClientState = (
   clientStateConfig: ClientStateConfig = { resolvers: {}, defaults: {} },
 ) => {
-  const {
-    resolvers,
-    defaults,
-    cache,
-    typeDefs,
-    fragmentMatcher,
-  } = clientStateConfig;
+  const { defaults, cache, typeDefs, fragmentMatcher } = clientStateConfig;
   if (cache && defaults) {
     cache.writeData({ data: defaults });
   }
@@ -67,6 +61,10 @@ export const withClientState = (
 
       if (!isClient) return forward(operation);
 
+      const resolvers =
+        typeof clientStateConfig.resolvers === 'function'
+          ? clientStateConfig.resolvers()
+          : clientStateConfig.resolvers;
       const server = removeClientSetsFromDocument(operation.query);
       const { query } = operation;
       const type =

--- a/packages/apollo-link-state/src/utils.ts
+++ b/packages/apollo-link-state/src/utils.ts
@@ -1,9 +1,6 @@
 import { DocumentNode, DirectiveNode } from 'graphql';
 
-import {
-  checkDocument,
-  removeDirectivesFromDocument,
-} from 'apollo-utilities';
+import { checkDocument, removeDirectivesFromDocument } from 'apollo-utilities';
 
 const connectionRemoveConfig = {
   test: (directive: DirectiveNode) => directive.name.value === 'client',


### PR DESCRIPTION
<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [x] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->

So we can lazy load resolvers