### PR TITLE
Fix: when alias returns a falsy value, it may return undefined

### DIFF
--- a/packages/apollo-link-state/src/index.ts
+++ b/packages/apollo-link-state/src/index.ts
@@ -87,8 +87,10 @@ export const withClientState = (
         const aliasNeeded = resultKey !== fieldName;
 
         // If aliasedValue is defined, some other link or server already returned a value
-        if (aliasedNode !== undefined || preAliasingNode !== undefined) {
-          return aliasedNode || preAliasingNode;
+        if (aliasedNode !== undefined) {
+          return aliasedNode;
+        } else if (preAliasingNode !== undefined) {
+          return preAliasingNode;
         }
 
         // Look for the field in the custom resolver map


### PR DESCRIPTION
<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [x] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->

Hi! I had an aliased field vanishing from the local state, which after some investigation seem to have been solved by splitting up the return statement as shown in this PR.