### PR TITLE
fix #308

### DIFF
--- a/packages/apollo-link-state/src/utils.ts
+++ b/packages/apollo-link-state/src/utils.ts
@@ -1,6 +1,7 @@
 // importing print is a reasonable thing to do, since Apollo Link Http requires
 // it to be present
-import { DocumentNode, DirectiveNode, print } from 'graphql';
+import { DocumentNode, DirectiveNode } from 'graphql';
+import { print } from 'graphql/language/printer';
 
 import { checkDocument, removeDirectivesFromDocument } from 'apollo-utilities';
 


### PR DESCRIPTION
This fix addresses issue #308 
```
Failed to compile.

./node_modules/apollo-link-state/lib/utils.js 21:51-56
  'graphql' does not contain an export named 'print'.
```

Until this is merged people can use my adoption at:
https://www.npmjs.com/package/@tgrx/apollo-link-state