### PR TITLE
define resolver type

### DIFF
--- a/packages/apollo-link-state/src/index.ts
+++ b/packages/apollo-link-state/src/index.ts
@@ -19,9 +19,29 @@ import { removeClientSetsFromDocument, normalizeTypeDefs } from './utils';
 
 const capitalizeFirstLetter = str => str.charAt(0).toUpperCase() + str.slice(1);
 
+export type ResolverContext = {
+  cache: ApolloCache<any>;
+};
+
+export type ResolveFunction<TA = any> = (
+  rootValue?: any,
+  args?: TA,
+  context?: ResolverContext,
+  info?: any,
+) => any;
+
+export type ResolverMap = {
+  [name: string]: ResolveFunction;
+};
+
+export type Resolvers = {
+  Query?: ResolverMap;
+  Mutation?: ResolverMap;
+};
+
 export type ClientStateConfig = {
   cache?: ApolloCache<any>;
-  resolvers: any | (() => any);
+  resolvers: Resolvers | (() => Resolvers);
   defaults?: any;
   typeDefs?: string | string[] | DocumentNode | DocumentNode[];
   fragmentMatcher?: FragmentMatcher;


### PR DESCRIPTION
<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [x] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->

I want TypeScript support to know what methods/props the context `cache` has.